### PR TITLE
Create Requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+requests
+lxml


### PR DESCRIPTION
Instead of checking the file and manually downloading with `pip install requirements.txt` a user can install it with only one command 